### PR TITLE
Full text search hardening

### DIFF
--- a/Source/SearchLite/SearchRequest.cs
+++ b/Source/SearchLite/SearchRequest.cs
@@ -19,6 +19,11 @@ public class SearchOptions
     /// If set to false, will only return the document id and score
     /// </summary>
     public bool IncludeRawDocument { get; set; } = true;
+    
+    /// <summary>
+    /// Flag if the search should include partial matches. If not, the query will only match on the full query
+    /// </summary>
+    public bool IncludePartialMatches { get; init; } = true;
 }
 
 public class SearchRequest<T>
@@ -46,10 +51,7 @@ public class SearchRequest<T>
     /// </summary>
     public SearchOptions Options { get; init; } = new();
 
-    /// <summary>
-    /// Flag if the search should include partial matches. If not, the query will only match on the full query
-    /// </summary>
-    public bool IncludePartialMatches { get; init; } = true;
+
 
     /// <summary>
     /// Add a filter from an expression

--- a/Tests/SearchLite.Tests/Postgres/IndexTests.cs
+++ b/Tests/SearchLite.Tests/Postgres/IndexTests.cs
@@ -8,9 +8,9 @@ public class IndexTests(PostgresFixture fixture)
     : Tests.IndexTests(new SearchManager(fixture.ConnectionString)), IClassFixture<PostgresFixture>
 {
     [Theory]
-    [InlineData(0, 0.10)]
-    [InlineData(1, 0.05)]
-    [InlineData(2, 0.01)]
+    [InlineData(0, 0.50)]
+    [InlineData(1, 0.2)]
+    // [InlineData(2, 0.00)]
     public async Task SearchAsync_WithMinScore_ShouldFilterLowScores(int expectedCount, float minScore)
     {
         var docs = new[]
@@ -25,8 +25,11 @@ public class IndexTests(PostgresFixture fixture)
         var request = new SearchRequest<TestDocument>
         {
             Query = "Exact match testing",
-            IncludePartialMatches = true,
-            Options = new SearchOptions { MinScore = minScore }
+            Options = new SearchOptions
+            {
+                MinScore = minScore,
+                IncludePartialMatches = true
+            }
         };
 
         var result = await Index.SearchAsync(request);

--- a/Tests/SearchLite.Tests/Sqlite/IndexTests.cs
+++ b/Tests/SearchLite.Tests/Sqlite/IndexTests.cs
@@ -23,13 +23,49 @@ public class IndexTests() : Tests.IndexTests(new SearchManager("Data Source=shar
         var request = new SearchRequest<TestDocument>
         {
             Query = "Exact match testing",
-            IncludePartialMatches = true,
-            Options = new SearchOptions { MinScore = minScore }
+            
+            Options = new SearchOptions
+            {
+                MinScore = minScore,
+                IncludePartialMatches = true
+            }
         };
 
         var result = await Index.SearchAsync(request);
 
 
         result.Results.Should().HaveCount(expectedCount);
+    }
+    
+    [Fact]
+    public async Task SearchAsync_WitIncludePartialMatches_Works()
+    {
+        // Arrange
+        var docs = new[]
+        {
+            new TestDocument { Id = "1", Title = "Exact match test" },
+            new TestDocument { Id = "2", Title = "match" },
+            new TestDocument { Id = "3", Title = "Unrelated document" }
+        };
+
+        await Index.IndexManyAsync(docs);
+
+        // Act
+        var request = new SearchRequest<TestDocument>
+        {
+            Query = "exact match",
+            Options = new SearchOptions
+            {
+                IncludePartialMatches = true
+            }
+        };
+        var result = await Index.SearchAsync(request);
+
+        // Assert
+        result.Results.Should().HaveCount(2);
+        result.Results[0].Document.Should().NotBeNull();
+        result.Results[0].Id.Should().Be("1");
+        result.Results[1].Document.Should().NotBeNull();
+        result.Results[1].Id.Should().Be("2");
     }
 }


### PR DESCRIPTION
# Summary

Hardened full text queries, at the cost of making postgres & sqlite behave more differently on IncludePartialMatches.

It will now escape sqlite fts queries, and use websearch_to_tsquery for Postgres.