### PR TITLE
Add nested-field and collection filtering across Postgres and SQLite

### DIFF
--- a/.claude/hooks/ensure-dotnet10.sh
+++ b/.claude/hooks/ensure-dotnet10.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# SessionStart hook: ensure the .NET 10 SDK is available for Claude Code on the web.
+#
+# SearchLite multi-targets net8.0;net9.0;net10.0, so building and testing requires
+# the .NET 10 SDK. Remote sessions start from a clean container without it, so
+# install it here before the agent runs. On Ubuntu 24.04 the SDK ships in the
+# standard archives, so a plain apt install works without adding the Microsoft
+# package feed.
+set -euo pipefail
+
+# Only run in Claude Code on the web (remote) environments. Local machines are
+# expected to have their own SDK installed.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Idempotent: nothing to do if a .NET 10 SDK is already present.
+if command -v dotnet >/dev/null 2>&1 && dotnet --list-sdks 2>/dev/null | grep -q '^10\.'; then
+  echo "[session-start] .NET 10 SDK already present: $(dotnet --version)"
+  exit 0
+fi
+
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+  SUDO="sudo"
+fi
+
+echo "[session-start] Installing .NET 10 SDK (dotnet-sdk-10.0) via apt..."
+export DEBIAN_FRONTEND=noninteractive
+$SUDO apt-get update
+$SUDO apt-get install -y dotnet-sdk-10.0
+
+echo "[session-start] Installed .NET SDK $(dotnet --version)"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/ensure-dotnet10.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,7 +9,7 @@ on:
     types: [ published ]
 
 env:
-  DOTNET_VERSION: '9.0.x'
+  DOTNET_VERSION: '10.0.x'
   SOLUTION_FILE: ""
 
 permissions:
@@ -28,7 +28,10 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
 
       - name: Restore dependencies
         run: dotnet restore ${{ env.SOLUTION_FILE }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+    <!-- Enabled so the native SQLite binary below can be pinned transitively. -->
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4">
@@ -9,7 +10,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="FluentAssertions" Version="[7.2, 8)" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <!-- Pin the native SQLite binary forward of the GHSA-2m69-gcr7-jv3q advisory
+         (covers all 2.x); Microsoft.Data.Sqlite still resolves the managed core. -->
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.203" />
     <PackageVersion Include="Npgsql" Version="9.0.3" />

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -10,7 +10,7 @@
         <PackageIcon>icon.png</PackageIcon>
         <PackageReadmeFile>readme.nuget.md</PackageReadmeFile>
 
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/Source/SearchLite.Postgres/SearchIndex.cs
+++ b/Source/SearchLite.Postgres/SearchIndex.cs
@@ -208,7 +208,11 @@ public partial class SearchIndex<T> : ISearchIndex<T> where T : ISearchableDocum
         {
             // Convert property name to jsonb path and direction
             var direction = order.Direction == SortDirection.Ascending ? "ASC" : "DESC";
-            return $"document->'{order.PropertyName}' {direction}";
+            var segments = FieldPath.Split(order.PropertyName);
+            var accessor = segments.Length == 1
+                ? $"document->'{segments[0]}'"
+                : $"document #> '{{{string.Join(",", segments)}}}'";
+            return $"{accessor} {direction}";
         });
         return $"ORDER BY {string.Join(", ", orderClauses)}";
     }

--- a/Source/SearchLite.Postgres/WhereClauseBuilder.cs
+++ b/Source/SearchLite.Postgres/WhereClauseBuilder.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Npgsql;
 
 namespace SearchLite.Postgres;
@@ -59,9 +61,27 @@ public static class WhereClauseBuilder<T>
             : conditions.FirstOrDefault() ?? "TRUE";
     }
 
+    /// <summary>
+    /// Builds a path-aware JSONB text accessor for the given dotted property path.
+    /// 1 segment  -> (document->>'seg')
+    /// N segments -> (document #>> '{seg1,seg2,...}')
+    /// </summary>
+    private static string BuildTextAccessor(string propertyName)
+    {
+        var segments = FieldPath.Split(propertyName);
+        return segments.Length == 1
+            ? $"(document->>'{segments[0]}')"
+            : $"(document #>> '{{{string.Join(",", segments)}}}')";
+    }
+
     private static string BuildConditionSql(FilterNode<T>.Condition condition, ref int paramCounter,
         List<NpgsqlParameter> parameters)
     {
+        if (IsCollectionOperator(condition.Operator))
+        {
+            return BuildCollectionCondition(condition, ref paramCounter, parameters);
+        }
+
         if (IsNullOperator(condition.Operator))
         {
             return BuildNullCondition(condition.PropertyName, condition.Operator);
@@ -82,26 +102,26 @@ public static class WhereClauseBuilder<T>
             return BuildStringCondition(condition, ref paramCounter, parameters);
         }
 
+        var underlyingType = Nullable.GetUnderlyingType(condition.PropertyType) ?? condition.PropertyType;
+
+        // Equal/NotEqual on containment-eligible types use JSONB @> so the GIN index is used.
+        if ((condition.Operator is Operator.Equal or Operator.NotEqual)
+            && IsContainmentEligible(underlyingType))
+        {
+            return BuildContainmentEqualityCondition(condition, underlyingType, ref paramCounter, parameters);
+        }
+
+        var fieldExpression = BuildTextAccessor(condition.PropertyName);
         var postgresType = GetPostgresType(condition.PropertyType, condition.PropertyName);
         var operatorString = GetOperatorString(condition.Operator);
         var paramName = $"@p{paramCounter++}";
 
         object? paramValue = condition.Value;
-        var underlyingType = Nullable.GetUnderlyingType(condition.PropertyType) ?? condition.PropertyType;
 
         if (underlyingType.IsEnum)
         {
-            var prop = typeof(T).GetProperty(condition.PropertyName, System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.IgnoreCase);
-            EnumSerializationFormat format;
-            if (prop != null)
-            {
-                format = EnumSerializationAnalyzer.GetPropertyFormat(prop);
-            }
-            else
-            {
-                format = EnumSerializationAnalyzer.GetDefaultFormat(underlyingType);
-            }
-            
+            var format = ResolveEnumFormat(condition.PropertyName, underlyingType);
+
             if (format == EnumSerializationFormat.String)
             {
                 paramValue = condition.Value?.ToString();
@@ -114,7 +134,146 @@ public static class WhereClauseBuilder<T>
 
         parameters.Add(new NpgsqlParameter(paramName, paramValue ?? DBNull.Value));
 
-        return $"(document->>'{condition.PropertyName}'){postgresType} {operatorString} {paramName}";
+        return $"{fieldExpression}{postgresType} {operatorString} {paramName}";
+    }
+
+    /// <summary>
+    /// Underlying types for which JSONB containment (@>) reliably matches the stored representation.
+    /// </summary>
+    private static bool IsContainmentEligible(Type underlyingType)
+    {
+        if (underlyingType.IsEnum) return true;
+
+        return underlyingType == typeof(string)
+               || underlyingType == typeof(bool)
+               || underlyingType == typeof(Guid)
+               || underlyingType == typeof(int)
+               || underlyingType == typeof(long)
+               || underlyingType == typeof(short)
+               || underlyingType == typeof(byte);
+    }
+
+    private static EnumSerializationFormat ResolveEnumFormat(string propertyName, Type underlyingType)
+    {
+        var prop = typeof(T).GetProperty(propertyName, System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.IgnoreCase);
+        return prop != null
+            ? EnumSerializationAnalyzer.GetPropertyFormat(prop)
+            : EnumSerializationAnalyzer.GetDefaultFormat(underlyingType);
+    }
+
+    /// <summary>
+    /// Produces the JSON node representation of a scalar leaf value, honoring enum format.
+    /// </summary>
+    private static JsonNode? BuildLeafJson(object? value, Type underlyingType, string propertyName)
+    {
+        if (value == null) return null;
+
+        if (underlyingType.IsEnum)
+        {
+            var format = ResolveEnumFormat(propertyName, underlyingType);
+            if (format == EnumSerializationFormat.String)
+            {
+                return JsonValue.Create(value.ToString());
+            }
+
+            var numeric = Convert.ChangeType(value, underlyingType.GetEnumUnderlyingType());
+            return JsonSerializer.SerializeToNode(numeric, numeric!.GetType());
+        }
+
+        if (underlyingType == typeof(Guid))
+        {
+            return JsonValue.Create(((Guid)value).ToString("D"));
+        }
+
+        if (underlyingType == typeof(string))
+        {
+            return JsonValue.Create((string)value);
+        }
+
+        if (underlyingType == typeof(bool))
+        {
+            return JsonValue.Create((bool)value);
+        }
+
+        // Integer types: serialize as JSON numbers.
+        return JsonSerializer.SerializeToNode(value, underlyingType);
+    }
+
+    /// <summary>
+    /// Wraps a leaf JSON node inside a nested object following the dotted path.
+    /// e.g. path "Author.Name", leaf "Alice" -> {"Author":{"Name":"Alice"}}
+    /// </summary>
+    private static string BuildPathJson(string propertyName, JsonNode? leaf)
+    {
+        var segments = FieldPath.Split(propertyName);
+        JsonNode? node = leaf;
+        for (var i = segments.Length - 1; i >= 0; i--)
+        {
+            var obj = new JsonObject { [segments[i]] = node };
+            node = obj;
+        }
+
+        return node!.ToJsonString();
+    }
+
+    private static string BuildContainmentEqualityCondition(FilterNode<T>.Condition condition, Type underlyingType,
+        ref int paramCounter, List<NpgsqlParameter> parameters)
+    {
+        var leaf = BuildLeafJson(condition.Value, underlyingType, condition.PropertyName);
+        var json = BuildPathJson(condition.PropertyName, leaf);
+
+        var paramName = $"@p{paramCounter++}";
+        parameters.Add(new NpgsqlParameter(paramName, json));
+
+        return condition.Operator == Operator.Equal
+            ? $"document @> {paramName}::jsonb"
+            : $"NOT (document @> {paramName}::jsonb)";
+    }
+
+    private static bool IsCollectionOperator(Operator op)
+    {
+        return op is Operator.CollectionContains or Operator.CollectionNotContains;
+    }
+
+    private static string BuildCollectionCondition(FilterNode<T>.Condition condition, ref int paramCounter,
+        List<NpgsqlParameter> parameters)
+    {
+        var elementType = GetElementType(condition.PropertyType);
+        var underlyingElementType = Nullable.GetUnderlyingType(elementType) ?? elementType;
+
+        var leaf = BuildLeafJson(condition.Value, underlyingElementType, condition.PropertyName);
+        var array = new JsonArray { leaf };
+        var json = BuildPathJson(condition.PropertyName, array);
+
+        var paramName = $"@p{paramCounter++}";
+        parameters.Add(new NpgsqlParameter(paramName, json));
+
+        return condition.Operator == Operator.CollectionContains
+            ? $"document @> {paramName}::jsonb"
+            : $"NOT (document @> {paramName}::jsonb)";
+    }
+
+    private static Type GetElementType(Type collectionType)
+    {
+        if (collectionType.IsArray)
+        {
+            return collectionType.GetElementType()!;
+        }
+
+        if (collectionType.IsGenericType)
+        {
+            return collectionType.GetGenericArguments()[0];
+        }
+
+        // IEnumerable<TElem> implemented somewhere in the hierarchy.
+        var enumerableInterface = collectionType.GetInterfaces()
+            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+        if (enumerableInterface != null)
+        {
+            return enumerableInterface.GetGenericArguments()[0];
+        }
+
+        throw new NotSupportedException($"Cannot determine element type for collection type {collectionType}");
     }
 
     private static string GetPostgresType(Type type, string propertyName)
@@ -182,7 +341,7 @@ public static class WhereClauseBuilder<T>
 
     private static string BuildNullCondition(string propertyName, Operator op)
     {
-        var fieldExpression = $"(document->>'{propertyName}')";
+        var fieldExpression = BuildTextAccessor(propertyName);
 
         return op switch
         {
@@ -194,7 +353,7 @@ public static class WhereClauseBuilder<T>
 
     private static string BuildStringNullOrEmptyCondition(string propertyName, Operator op)
     {
-        var fieldExpression = $"(document->>'{propertyName}')";
+        var fieldExpression = BuildTextAccessor(propertyName);
 
         return op switch
         {
@@ -223,9 +382,10 @@ public static class WhereClauseBuilder<T>
 
     private static string BuildSetCondition(FilterNode<T>.Condition condition, ref int paramCounter, List<NpgsqlParameter> parameters)
     {
+        var accessor = BuildTextAccessor(condition.PropertyName);
         var fieldExpression = condition.PropertyType == typeof(string)
-            ? $"(document->>'{condition.PropertyName}')::text"
-            : $"(document->>'{condition.PropertyName}'){GetPostgresType(condition.PropertyType, condition.PropertyName)}";
+            ? $"{accessor}::text"
+            : $"{accessor}{GetPostgresType(condition.PropertyType, condition.PropertyName)}";
 
         return condition.Operator switch
         {
@@ -237,7 +397,7 @@ public static class WhereClauseBuilder<T>
 
     private static string BuildStringCondition(FilterNode<T>.Condition condition, ref int paramCounter, List<NpgsqlParameter> parameters)
     {
-        var fieldExpression = $"(document->>'{condition.PropertyName}')::text";
+        var fieldExpression = $"{BuildTextAccessor(condition.PropertyName)}::text";
 
         return condition.Operator switch
         {
@@ -299,7 +459,7 @@ public static class WhereClauseBuilder<T>
                     {
                         format = EnumSerializationAnalyzer.GetDefaultFormat(underlyingType);
                     }
-                    
+
                     if (format == EnumSerializationFormat.String)
                     {
                         paramValue = item?.ToString();

--- a/Source/SearchLite.Sqlite/WhereClauseBuilder.cs
+++ b/Source/SearchLite.Sqlite/WhereClauseBuilder.cs
@@ -72,6 +72,11 @@ public static class WhereClauseBuilder<T>
             return BuildStringNullOrEmptyCondition(condition.PropertyName, condition.Operator);
         }
 
+        if (IsCollectionContainsOperator(condition.Operator))
+        {
+            return BuildCollectionContainsCondition(condition, ref paramCounter, parameters);
+        }
+
         if (IsSetOperator(condition.Operator))
         {
             return BuildSetCondition(condition, ref paramCounter, parameters);
@@ -215,6 +220,79 @@ public static class WhereClauseBuilder<T>
     private static bool IsSetOperator(Operator op)
     {
         return op is Operator.In or Operator.NotIn;
+    }
+
+    private static bool IsCollectionContainsOperator(Operator op)
+    {
+        return op is Operator.CollectionContains or Operator.CollectionNotContains;
+    }
+
+    private static string BuildCollectionContainsCondition(FilterNode<T>.Condition condition, ref int paramCounter, List<SqliteParameter> parameters)
+    {
+        var paramName = $"@p{paramCounter++}";
+
+        // PropertyType is the collection type (e.g. List<string>, int[]). Derive the element type
+        // so the searched value is typed the same way scalar params are typed elsewhere.
+        var elementType = GetCollectionElementType(condition.PropertyType);
+        var underlyingType = Nullable.GetUnderlyingType(elementType) ?? elementType;
+
+        object? paramValue = condition.Value;
+
+        if (underlyingType.IsEnum)
+        {
+            // For enum elements the property lookup uses the leaf segment of the dotted path; the
+            // enum format only depends on the enum type / member converters, so a type-level
+            // fallback gives a correct result for nested array fields as well.
+            var format = EnumSerializationAnalyzer.GetDefaultFormat(underlyingType);
+
+            if (format == EnumSerializationFormat.String)
+            {
+                paramValue = condition.Value?.ToString();
+            }
+            else
+            {
+                if (condition.Value != null)
+                    paramValue = Convert.ChangeType(condition.Value, underlyingType.GetEnumUnderlyingType());
+            }
+        }
+        else if (underlyingType == typeof(Guid))
+        {
+            paramValue = condition.Value?.ToString();
+        }
+
+        parameters.Add(new SqliteParameter(paramName, paramValue ?? DBNull.Value));
+
+        var existsClause = $"EXISTS (SELECT 1 FROM json_each(document, '$.{condition.PropertyName}') WHERE value = {paramName})";
+
+        return condition.Operator switch
+        {
+            Operator.CollectionContains => existsClause,
+            Operator.CollectionNotContains => $"NOT {existsClause}",
+            _ => throw new NotSupportedException($"Collection operator {condition.Operator} is not supported")
+        };
+    }
+
+    private static Type GetCollectionElementType(Type collectionType)
+    {
+        if (collectionType.IsArray)
+        {
+            return collectionType.GetElementType()!;
+        }
+
+        if (collectionType.IsGenericType)
+        {
+            return collectionType.GetGenericArguments()[0];
+        }
+
+        var enumerableInterface = collectionType.GetInterfaces()
+            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+
+        if (enumerableInterface != null)
+        {
+            return enumerableInterface.GetGenericArguments()[0];
+        }
+
+        throw new NotSupportedException($"Cannot determine element type for collection type {collectionType}");
     }
 
     private static bool IsStringOperator(Operator op)

--- a/Source/SearchLite/FieldPath.cs
+++ b/Source/SearchLite/FieldPath.cs
@@ -1,0 +1,68 @@
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace SearchLite;
+
+/// <summary>
+/// Helpers for turning a parameter-rooted member access expression (e.g. <c>d =&gt; d.Author.Name</c>)
+/// into a dot-separated field path ("Author.Name"), and for splitting such paths back into segments.
+/// </summary>
+public static class FieldPath
+{
+    /// <summary>
+    /// Builds a dot-separated path from a member access chain rooted at the lambda parameter.
+    /// Throws if the expression is not rooted at the parameter (e.g. a captured variable).
+    /// </summary>
+    public static string From(MemberExpression member)
+    {
+        if (!TryFrom(member, out var path))
+        {
+            throw new NotSupportedException(
+                $"Expression '{member}' is not a document field access. Only member access rooted at the document parameter is supported.");
+        }
+
+        return path;
+    }
+
+    /// <summary>
+    /// Attempts to build a dot-separated path from a member access chain rooted at the lambda
+    /// parameter. Returns false when the chain is rooted in something other than the parameter
+    /// (for example a captured local/field), which callers use to distinguish a document field
+    /// from a value to evaluate.
+    /// </summary>
+    public static bool TryFrom(Expression? expression, out string path)
+    {
+        path = string.Empty;
+
+        if (expression is UnaryExpression { NodeType: ExpressionType.Convert } convert)
+        {
+            expression = convert.Operand;
+        }
+
+        if (expression is not MemberExpression member)
+        {
+            return false;
+        }
+
+        var segments = new Stack<string>();
+        Expression? current = member;
+        while (current is MemberExpression m && m.Member is PropertyInfo property)
+        {
+            segments.Push(property.Name);
+            current = m.Expression;
+        }
+
+        if (current is not ParameterExpression)
+        {
+            return false;
+        }
+
+        path = string.Join(".", segments);
+        return true;
+    }
+
+    /// <summary>
+    /// Splits a dot-separated field path into its segments.
+    /// </summary>
+    public static string[] Split(string path) => path.Split('.');
+}

--- a/Source/SearchLite/FilterMapper.cs
+++ b/Source/SearchLite/FilterMapper.cs
@@ -501,12 +501,16 @@ public static class FilterMapper
         /// </summary>
         private static (Expression collection, Expression item) ExtractContainsOperands(MethodCallExpression method)
         {
-            if (method.Object == null && method.Arguments.Count == 2)
+            // Static form: Enumerable.Contains(collection, item) or the MemoryExtensions span
+            // overloads Contains(span, value[, comparer]) — collection and item are the first two
+            // arguments; any trailing comparer argument is ignored.
+            if (method.Object == null && method.Arguments.Count >= 2)
             {
                 return (method.Arguments[0], method.Arguments[1]);
             }
 
-            if (method.Object != null && method.Arguments.Count == 1)
+            // Instance form: collection.Contains(item[, comparer]).
+            if (method.Object != null && method.Arguments.Count >= 1)
             {
                 return (method.Object, method.Arguments[0]);
             }

--- a/Source/SearchLite/FilterMapper.cs
+++ b/Source/SearchLite/FilterMapper.cs
@@ -66,7 +66,7 @@ public static class FilterMapper
             var propertyInfo = (PropertyInfo)member.Member;
             return new FilterNode<T>.Condition
             {
-                PropertyName = propertyInfo.Name,
+                PropertyName = FieldPath.From(member),
                 PropertyType = propertyInfo.PropertyType!,
                 Operator = Operator.Equal,
                 Value = true
@@ -78,7 +78,7 @@ public static class FilterMapper
             var propertyInfo = (PropertyInfo)member.Member;
             return new FilterNode<T>.Condition
             {
-                PropertyName = propertyInfo.Name,
+                PropertyName = FieldPath.From(member),
                 PropertyType = propertyInfo.PropertyType!,
                 Operator = Operator.Equal,
                 Value = false
@@ -152,7 +152,7 @@ public static class FilterMapper
 
                 return new FilterNode<T>.Condition
                 {
-                    PropertyName = propertyInfo.Name,
+                    PropertyName = FieldPath.From(memberExpression),
                     PropertyType = propertyInfo.PropertyType!,
                     Operator = nullOperator,
                     Value = true // Use true as a placeholder since we don't need the actual value for null checks
@@ -164,7 +164,7 @@ public static class FilterMapper
 
             return new FilterNode<T>.Condition
             {
-                PropertyName = propertyInfo.Name,
+                PropertyName = FieldPath.From(memberExpression),
                 PropertyType = propertyInfo.PropertyType!,
                 Operator = operatorType,
                 Value = value!
@@ -185,13 +185,13 @@ public static class FilterMapper
 
             return methodCall.Method.Name switch
             {
-                nameof(IComparable.CompareTo) or "CompareTo" => HandleCompareToComparison(methodCall, propertyInfo, node.NodeType, comparisonResult),
-                nameof(object.ToString) => HandleToStringComparison(propertyInfo, node.NodeType, comparisonResult),
+                nameof(IComparable.CompareTo) or "CompareTo" => HandleCompareToComparison(methodCall, memberExpression, propertyInfo, node.NodeType, comparisonResult),
+                nameof(object.ToString) => HandleToStringComparison(memberExpression, propertyInfo, node.NodeType, comparisonResult),
                 _ => throw new NotSupportedException($"Method {methodCall.Method.Name} is not supported in binary comparisons")
             };
         }
 
-        private FilterNode<T> HandleCompareToComparison(MethodCallExpression methodCall, PropertyInfo propertyInfo, 
+        private FilterNode<T> HandleCompareToComparison(MethodCallExpression methodCall, MemberExpression memberExpression, PropertyInfo propertyInfo,
             ExpressionType nodeType, object? comparisonResult)
         {
             var compareValue = Expression.Lambda(methodCall.Arguments[0]).Compile().DynamicInvoke();
@@ -237,14 +237,14 @@ public static class FilterMapper
 
             return new FilterNode<T>.Condition
             {
-                PropertyName = propertyInfo.Name,
+                PropertyName = FieldPath.From(memberExpression),
                 PropertyType = propertyInfo.PropertyType!,
                 Operator = operatorType,
                 Value = compareValue!
             };
         }
 
-        private FilterNode<T> HandleToStringComparison(PropertyInfo propertyInfo, ExpressionType nodeType, object? comparisonResult)
+        private FilterNode<T> HandleToStringComparison(MemberExpression memberExpression, PropertyInfo propertyInfo, ExpressionType nodeType, object? comparisonResult)
         {
             if (comparisonResult is not string stringValue)
             {
@@ -260,7 +260,7 @@ public static class FilterMapper
 
             return new FilterNode<T>.Condition
             {
-                PropertyName = propertyInfo.Name,
+                PropertyName = FieldPath.From(memberExpression),
                 PropertyType = propertyInfo.PropertyType!,
                 Operator = operatorType,
                 Value = stringValue
@@ -356,13 +356,13 @@ public static class FilterMapper
             }
 
             var propertyInfo = (PropertyInfo)memberExpression.Member;
-            var operatorType = method.Method.Name == nameof(string.IsNullOrEmpty) 
-                ? Operator.IsNullOrEmpty 
+            var operatorType = method.Method.Name == nameof(string.IsNullOrEmpty)
+                ? Operator.IsNullOrEmpty
                 : Operator.IsNullOrWhiteSpace;
 
             return new FilterNode<T>.Condition
             {
-                PropertyName = propertyInfo.Name,
+                PropertyName = FieldPath.From(memberExpression),
                 PropertyType = propertyInfo.PropertyType!,
                 Operator = operatorType,
                 Value = true
@@ -377,13 +377,13 @@ public static class FilterMapper
             }
 
             var propertyInfo = (PropertyInfo)memberExpression.Member;
-            var operatorType = method.Method.Name == nameof(string.IsNullOrEmpty) 
-                ? Operator.IsNotNullOrEmpty 
+            var operatorType = method.Method.Name == nameof(string.IsNullOrEmpty)
+                ? Operator.IsNotNullOrEmpty
                 : Operator.IsNotNullOrWhiteSpace;
 
             return new FilterNode<T>.Condition
             {
-                PropertyName = propertyInfo.Name,
+                PropertyName = FieldPath.From(memberExpression),
                 PropertyType = propertyInfo.PropertyType!,
                 Operator = operatorType,
                 Value = true
@@ -425,68 +425,48 @@ public static class FilterMapper
 
         private FilterNode<T> VisitSetOperatorMethod(MethodCallExpression method)
         {
-            // Handle collection.Contains (both static Enumerable.Contains and instance Contains)
-            MemberExpression? targetMember = null;
-            object? collectionValue = null;
+            // Contains comes in two shapes that we map to different operators depending on which
+            // operand is the document field (the parameter-rooted member):
+            //   1. constantCollection.Contains(d.Field)  => In        (value set membership)
+            //   2. d.Collection.Contains(constant)        => CollectionContains (array field holds value)
+            var (collectionExpr, itemExpr) = ExtractContainsOperands(method);
 
-            if (method.Method.Name == nameof(Enumerable.Contains) && method.Method.DeclaringType == typeof(Enumerable))
+            var itemMember = AsParameterRootedMember(itemExpr);
+            var collectionMember = AsParameterRootedMember(collectionExpr);
+
+            // Case 1: the item is the document field, the collection is a constant.
+            if (itemMember != null && collectionMember == null)
             {
-                // Static Enumerable.Contains(collection, item)
-                if (method.Arguments.Count == 2 && method.Arguments[1] is MemberExpression member)
+                var leaf = (PropertyInfo)itemMember.Member;
+                var collectionValue = GetCollectionValue(collectionExpr)
+                    ?? throw new NotSupportedException("Unsupported Contains usage - unable to evaluate the collection");
+
+                return new FilterNode<T>.Condition
                 {
-                    targetMember = member;
-                    collectionValue = Expression.Lambda(method.Arguments[0]).Compile().DynamicInvoke();
-                }
-            }
-            else if (method.Method.Name == "Contains" && method.Method.DeclaringType?.FullName == "System.MemoryExtensions")
-            {
-                // MemoryExtensions.Contains (for Span<T>/ReadOnlySpan<T> operations on arrays)
-                if (method.Arguments.Count == 2 && method.Arguments[1] is MemberExpression member)
-                {
-                    targetMember = member;
-                    collectionValue = GetCollectionValue(method.Arguments[0]);
-                }
-            }
-            else if (method.Method.Name == "Contains" && method.Object != null)
-            {
-                // Instance collection.Contains(item)
-                if (method.Arguments.Count == 1 && method.Arguments[0] is MemberExpression member)
-                {
-                    targetMember = member;
-                    collectionValue = Expression.Lambda(method.Object).Compile().DynamicInvoke();
-                }
-            }
-            else if (method.Method.Name == "Contains")
-            {
-                // Handle extension method calls like array.Contains(x.Property)
-                // This is compiled as static method call: Contains(array, x.Property)
-                if (method.Arguments.Count == 2 && method.Arguments[1] is MemberExpression member)
-                {
-                    targetMember = member;
-                    collectionValue = GetCollectionValue(method.Arguments[0]);
-                }
-                // Handle instance method calls like list.Contains(x.Property) 
-                else if (method.Arguments.Count == 1 && method.Arguments[0] is MemberExpression member2 && method.Object != null)
-                {
-                    targetMember = member2;
-                    collectionValue = Expression.Lambda(method.Object).Compile().DynamicInvoke();
-                }
+                    PropertyName = FieldPath.From(itemMember),
+                    PropertyType = leaf.PropertyType,
+                    Operator = Operator.In,
+                    Value = collectionValue
+                };
             }
 
-            if (targetMember == null || collectionValue == null)
+            // Case 2: the collection is the document field (an array/list), the item is a constant.
+            if (collectionMember != null && itemMember == null)
             {
-                throw new NotSupportedException("Unsupported Contains usage - unable to extract property and collection");
+                var leaf = (PropertyInfo)collectionMember.Member;
+                var itemValue = Expression.Lambda(itemExpr).Compile().DynamicInvoke()
+                    ?? throw new NotSupportedException("Unsupported Contains usage - the searched value cannot be null");
+
+                return new FilterNode<T>.Condition
+                {
+                    PropertyName = FieldPath.From(collectionMember),
+                    PropertyType = leaf.PropertyType,
+                    Operator = Operator.CollectionContains,
+                    Value = itemValue
+                };
             }
 
-            var targetPropertyInfo = (PropertyInfo)targetMember.Member;
-
-            return new FilterNode<T>.Condition
-            {
-                PropertyName = targetPropertyInfo.Name,
-                PropertyType = targetPropertyInfo.PropertyType,
-                Operator = Operator.In,
-                Value = collectionValue
-            };
+            throw new NotSupportedException("Unsupported Contains usage - exactly one operand must be a document field");
         }
 
         private FilterNode<T> VisitNegatedSetOperatorMethod(MethodCallExpression method)
@@ -498,6 +478,7 @@ public static class FilterMapper
                 {
                     Operator.Contains => Operator.NotContains,
                     Operator.In => Operator.NotIn,
+                    Operator.CollectionContains => Operator.CollectionNotContains,
                     _ => throw new NotSupportedException($"Cannot negate operator {condition.Operator}")
                 };
 
@@ -511,6 +492,51 @@ public static class FilterMapper
             }
 
             throw new NotSupportedException("Cannot negate non-condition result");
+        }
+
+        /// <summary>
+        /// Extracts the (collection, item) operands from a Contains call, normalizing across the
+        /// static <c>Enumerable.Contains(collection, item)</c> / <c>MemoryExtensions.Contains</c>
+        /// forms and the instance <c>collection.Contains(item)</c> form.
+        /// </summary>
+        private static (Expression collection, Expression item) ExtractContainsOperands(MethodCallExpression method)
+        {
+            if (method.Object == null && method.Arguments.Count == 2)
+            {
+                return (method.Arguments[0], method.Arguments[1]);
+            }
+
+            if (method.Object != null && method.Arguments.Count == 1)
+            {
+                return (method.Object, method.Arguments[0]);
+            }
+
+            throw new NotSupportedException("Unsupported Contains usage - unable to extract operands");
+        }
+
+        /// <summary>
+        /// Returns the member expression when <paramref name="expression"/> is a member access
+        /// chain rooted at the lambda parameter (a document field); otherwise null.
+        /// </summary>
+        private static MemberExpression? AsParameterRootedMember(Expression? expression)
+        {
+            if (expression is UnaryExpression { NodeType: ExpressionType.Convert } convert)
+            {
+                expression = convert.Operand;
+            }
+
+            if (expression is not MemberExpression member)
+            {
+                return null;
+            }
+
+            Expression? current = member;
+            while (current is MemberExpression m)
+            {
+                current = m.Expression;
+            }
+
+            return current is ParameterExpression ? member : null;
         }
 
         private static object? GetCollectionValue(Expression expression)
@@ -561,7 +587,7 @@ public static class FilterMapper
 
             return new FilterNode<T>.Condition
             {
-                PropertyName = propertyInfo.Name,
+                PropertyName = FieldPath.From(memberExpression),
                 PropertyType = propertyInfo.PropertyType!,
                 Operator = operatorType,
                 Value = value!
@@ -646,7 +672,7 @@ public static class FilterMapper
             {
                 nameof(object.Equals) => new FilterNode<T>.Condition
                 {
-                    PropertyName = propertyInfo.Name,
+                    PropertyName = FieldPath.From(memberExpression),
                     PropertyType = propertyInfo.PropertyType!,
                     Operator = Operator.Equal,
                     Value = value!
@@ -709,7 +735,7 @@ public static class FilterMapper
 
                 return new FilterNode<T>.Condition
                 {
-                    PropertyName = propertyInfo.Name,
+                    PropertyName = FieldPath.From(memberExpression),
                     PropertyType = propertyInfo.PropertyType!,
                     Operator = Operator.NotEqual,
                     Value = value!

--- a/Source/SearchLite/FilterNode.cs
+++ b/Source/SearchLite/FilterNode.cs
@@ -4,6 +4,10 @@ public abstract record FilterNode<T>
 {
     public sealed record Condition : FilterNode<T>
     {
+        /// <summary>
+        /// The document field to filter on, encoded as a dot-separated path for nested
+        /// fields (e.g. "Author.Name"). Top-level fields are a single segment ("Views").
+        /// </summary>
         public required string PropertyName { get; init; }
         public required object Value { get; init; }
         public Operator Operator { get; init; }
@@ -44,7 +48,9 @@ public enum Operator
     EndsWithIgnoreCase,
     NotEndsWithIgnoreCase,
     In,
-    NotIn
+    NotIn,
+    CollectionContains,
+    CollectionNotContains
 }
 
 public enum LogicalOperator

--- a/Source/SearchLite/OrderByMapper.cs
+++ b/Source/SearchLite/OrderByMapper.cs
@@ -10,16 +10,21 @@ public static class OrderByMapper
     /// </summary>
     public static OrderByNode<T> Map<T, TKey>(Expression<Func<T, TKey>> keySelector, SortDirection direction)
     {
-        if (keySelector.Body is not MemberExpression memberExpression)
+        var body = keySelector.Body;
+        // Unwrap conversions inserted for value-type key selectors (e.g. enums, nullable).
+        if (body is UnaryExpression { NodeType: ExpressionType.Convert } convert)
         {
-            throw new ArgumentException("Only simple property access expressions are supported", nameof(keySelector));
+            body = convert.Operand;
         }
 
-        var propertyInfo = (PropertyInfo)memberExpression.Member;
+        if (body is not MemberExpression memberExpression)
+        {
+            throw new ArgumentException("Only property access expressions are supported", nameof(keySelector));
+        }
 
         return new OrderByNode<T>
         {
-            PropertyName = propertyInfo.Name,
+            PropertyName = FieldPath.From(memberExpression),
             Direction = direction
         };
     }

--- a/Tests/SearchLite.Tests/FilterMapperNestedTests.cs
+++ b/Tests/SearchLite.Tests/FilterMapperNestedTests.cs
@@ -1,0 +1,133 @@
+using System.Linq.Expressions;
+using FluentAssertions;
+
+namespace SearchLite.Tests;
+
+public class FilterMapperNestedTests
+{
+    private class Doc
+    {
+        public string Name { get; set; } = "";
+        public Inner? Author { get; set; }
+        public List<string> Labels { get; set; } = [];
+        public int[] Scores { get; set; } = [];
+    }
+
+    private class Inner
+    {
+        public string Name { get; set; } = "";
+        public int Age { get; set; }
+        public Deeper? Address { get; set; }
+    }
+
+    private class Deeper
+    {
+        public string City { get; set; } = "";
+    }
+
+    [Fact]
+    public void Map_NestedEquality_ProducesDottedPath()
+    {
+        Expression<Func<Doc, bool>> predicate = d => d.Author!.Name == "Alice";
+        var result = FilterMapper.Map(predicate);
+
+        result.Should().BeEquivalentTo(new FilterNode<Doc>.Condition
+        {
+            PropertyName = "Author.Name",
+            PropertyType = typeof(string),
+            Operator = Operator.Equal,
+            Value = "Alice"
+        });
+    }
+
+    [Fact]
+    public void Map_MultiLevelNesting_ProducesDottedPath()
+    {
+        Expression<Func<Doc, bool>> predicate = d => d.Author!.Address!.City == "Oslo";
+        var result = FilterMapper.Map(predicate);
+
+        result.Should().BeEquivalentTo(new FilterNode<Doc>.Condition
+        {
+            PropertyName = "Author.Address.City",
+            PropertyType = typeof(string),
+            Operator = Operator.Equal,
+            Value = "Oslo"
+        });
+    }
+
+    [Fact]
+    public void Map_NestedComparison_ProducesDottedPath()
+    {
+        Expression<Func<Doc, bool>> predicate = d => d.Author!.Age > 18;
+        var result = FilterMapper.Map(predicate);
+
+        result.Should().BeEquivalentTo(new FilterNode<Doc>.Condition
+        {
+            PropertyName = "Author.Age",
+            PropertyType = typeof(int),
+            Operator = Operator.GreaterThan,
+            Value = 18
+        });
+    }
+
+    [Fact]
+    public void Map_CollectionContains_ProducesCollectionContainsOperator()
+    {
+        Expression<Func<Doc, bool>> predicate = d => d.Labels.Contains("urgent");
+        var result = FilterMapper.Map(predicate);
+
+        result.Should().BeEquivalentTo(new FilterNode<Doc>.Condition
+        {
+            PropertyName = "Labels",
+            PropertyType = typeof(List<string>),
+            Operator = Operator.CollectionContains,
+            Value = "urgent"
+        });
+    }
+
+    [Fact]
+    public void Map_NegatedCollectionContains_ProducesCollectionNotContains()
+    {
+        Expression<Func<Doc, bool>> predicate = d => !d.Labels.Contains("urgent");
+        var result = FilterMapper.Map(predicate);
+
+        ((FilterNode<Doc>.Condition)result).Operator.Should().Be(Operator.CollectionNotContains);
+    }
+
+    [Fact]
+    public void Map_EnumerableContainsOnDocumentArray_ProducesCollectionContains()
+    {
+        Expression<Func<Doc, bool>> predicate = d => Enumerable.Contains(d.Scores, 5);
+        var result = FilterMapper.Map(predicate);
+
+        result.Should().BeEquivalentTo(new FilterNode<Doc>.Condition
+        {
+            PropertyName = "Scores",
+            PropertyType = typeof(int[]),
+            Operator = Operator.CollectionContains,
+            Value = 5
+        });
+    }
+
+    [Fact]
+    public void Map_ConstantCollectionContainsDocumentField_StillProducesIn()
+    {
+        var allowed = new[] { "a", "b" };
+        Expression<Func<Doc, bool>> predicate = d => allowed.Contains(d.Name);
+        var result = FilterMapper.Map(predicate);
+
+        var condition = (FilterNode<Doc>.Condition)result;
+        condition.PropertyName.Should().Be("Name");
+        condition.Operator.Should().Be(Operator.In);
+    }
+
+    [Fact]
+    public void OrderByMapper_NestedField_ProducesDottedPath()
+    {
+        Expression<Func<Doc, string>> selector = d => d.Author!.Name;
+        var node = OrderByMapper.Map(selector, SortDirection.Ascending);
+
+        node.PropertyName.Should().Be("Author.Name");
+        node.Direction.Should().Be(SortDirection.Ascending);
+    }
+}

--- a/Tests/SearchLite.Tests/IndexNestedTests.cs
+++ b/Tests/SearchLite.Tests/IndexNestedTests.cs
@@ -1,0 +1,158 @@
+using FluentAssertions;
+
+namespace SearchLite.Tests;
+
+/// <summary>
+/// Behavioral capability contract for complex queries (nested fields, nested OrderBy and
+/// collection membership). Every case here runs against both backends via the inheriting
+/// Postgres/Sqlite test classes, and is checked against in-memory LINQ as the oracle.
+/// </summary>
+public abstract partial class IndexTests
+{
+    private static TestDocument[] NestedDocs() =>
+    [
+        new TestDocument
+        {
+            Id = "1", Title = "Doc 1", CreatedAt = DateTime.UtcNow,
+            Author = new AuthorInfo { Name = "Alice", Age = 30, Address = new AddressInfo { City = "Oslo", Country = "NO" } },
+            Labels = ["urgent", "red"], Scores = [1, 2]
+        },
+        new TestDocument
+        {
+            Id = "2", Title = "Doc 2", CreatedAt = DateTime.UtcNow,
+            Author = new AuthorInfo { Name = "Bob", Age = 40, Address = new AddressInfo { City = "Bergen", Country = "NO" } },
+            Labels = ["red"], Scores = [2, 3]
+        },
+        new TestDocument
+        {
+            Id = "3", Title = "Doc 3", CreatedAt = DateTime.UtcNow,
+            Author = new AuthorInfo { Name = "Charlie", Age = 50, Address = null },
+            Labels = ["green", "urgent"], Scores = [3]
+        },
+        new TestDocument
+        {
+            Id = "4", Title = "Doc 4", CreatedAt = DateTime.UtcNow,
+            Author = new AuthorInfo { Name = "Alice", Age = 25, Address = new AddressInfo { City = "Oslo", Country = "NO" } },
+            Labels = [], Scores = []
+        },
+        new TestDocument
+        {
+            Id = "5", Title = "Doc 5", CreatedAt = DateTime.UtcNow,
+            Author = new AuthorInfo { Name = "Dave", Age = 40, Address = new AddressInfo { City = "Tromso", Country = "NO" } },
+            Labels = ["blue"], Scores = [5, 2]
+        }
+    ];
+
+    [Fact]
+    public async Task NestedField_Equality_ShouldFilter()
+    {
+        var docs = NestedDocs();
+        await Index.IndexManyAsync(docs);
+        await ShouldReturnSameResultsAsLinq(docs, d => d.Author!.Name == "Alice", 2);
+    }
+
+    [Fact]
+    public async Task NestedField_Comparison_ShouldFilter()
+    {
+        var docs = NestedDocs();
+        await Index.IndexManyAsync(docs);
+        await ShouldReturnSameResultsAsLinq(docs, d => d.Author!.Age >= 40, 3);
+        await ShouldReturnSameResultsAsLinq(docs, d => d.Author!.Age > 30 && d.Author.Age < 50, 2);
+    }
+
+    [Fact]
+    public async Task NestedField_MultiLevel_Equality_ShouldFilter()
+    {
+        var docs = NestedDocs();
+        await Index.IndexManyAsync(docs);
+        await ShouldReturnSameResultsAsLinq(docs,
+            d => d.Author!.Address != null && d.Author.Address.City == "Oslo", 2);
+    }
+
+    [Fact]
+    public async Task NestedField_NullChecks_ShouldFilter()
+    {
+        var docs = NestedDocs();
+        await Index.IndexManyAsync(docs);
+        await ShouldReturnSameResultsAsLinq(docs, d => d.Author!.Address == null, 1);
+        await ShouldReturnSameResultsAsLinq(docs, d => d.Author!.Address != null, 4);
+    }
+
+    [Fact]
+    public async Task NestedField_StringContains_ShouldFilter()
+    {
+        var docs = NestedDocs();
+        await Index.IndexManyAsync(docs);
+        await ShouldReturnSameResultsAsLinq(docs, d => d.Author!.Name.Contains("li"), 3);
+    }
+
+    [Fact]
+    public async Task NestedField_CombinedWithTopLevelAndArray_ShouldFilter()
+    {
+        var docs = NestedDocs();
+        await Index.IndexManyAsync(docs);
+        await ShouldReturnSameResultsAsLinq(docs,
+            d => d.Labels.Contains("urgent") || d.Author!.Name == "Bob", 3);
+    }
+
+    [Fact]
+    public async Task CollectionContains_String_ShouldFilter()
+    {
+        var docs = NestedDocs();
+        await Index.IndexManyAsync(docs);
+        await ShouldReturnSameResultsAsLinq(docs, d => d.Labels.Contains("urgent"), 2);
+    }
+
+    [Fact]
+    public async Task CollectionNotContains_String_ShouldFilter()
+    {
+        var docs = NestedDocs();
+        await Index.IndexManyAsync(docs);
+        await ShouldReturnSameResultsAsLinq(docs, d => !d.Labels.Contains("urgent"), 3);
+    }
+
+    [Fact]
+    public async Task CollectionContains_EnumerableForm_ShouldFilter()
+    {
+        var docs = NestedDocs();
+        await Index.IndexManyAsync(docs);
+        await ShouldReturnSameResultsAsLinq(docs, d => Enumerable.Contains(d.Labels, "red"), 2);
+    }
+
+    [Fact]
+    public async Task CollectionContains_IntElement_ShouldFilter()
+    {
+        var docs = NestedDocs();
+        await Index.IndexManyAsync(docs);
+        await ShouldReturnSameResultsAsLinq(docs, d => d.Scores.Contains(2), 3);
+    }
+
+    [Fact]
+    public async Task CollectionContains_EmptyArray_IsExcluded()
+    {
+        var docs = NestedDocs();
+        await Index.IndexManyAsync(docs);
+        // doc 4 has empty Labels and must never match a Contains filter.
+        await ShouldReturnSameResultsAsLinq(docs, d => d.Labels.Contains("red"), 2);
+    }
+
+    [Fact]
+    public async Task NestedField_OrderBy_ShouldOrder()
+    {
+        var docs = NestedDocs();
+        await Index.IndexManyAsync(docs);
+
+        var request = new SearchRequest<TestDocument>()
+            .OrderByAscending(d => d.Author!.Age)
+            .OrderByAscending(d => d.Author!.Name);
+
+        var expected = docs
+            .OrderBy(d => d.Author!.Age)
+            .ThenBy(d => d.Author!.Name)
+            .Select(d => d.Id)
+            .ToList();
+
+        var result = await Index.SearchAsync(request);
+        result.Results.Select(r => r.Document!.Id).Should().Equal(expected);
+    }
+}

--- a/Tests/SearchLite.Tests/IndexTests.cs
+++ b/Tests/SearchLite.Tests/IndexTests.cs
@@ -45,7 +45,25 @@ public abstract partial class IndexTests
 
         public DangerZone DangerLevel { get; init; } = DangerZone.Low;
 
+        // Nested object + collection fields for complex-query coverage.
+        public AuthorInfo? Author { get; init; }
+        public List<string> Labels { get; init; } = [];
+        public List<int> Scores { get; init; } = [];
+
         public string GetSearchText() => $"{Title} {Content} {Description} {Tags}";
+    }
+
+    public class AuthorInfo
+    {
+        public string Name { get; init; } = "";
+        public int Age { get; init; }
+        public AddressInfo? Address { get; init; }
+    }
+
+    public class AddressInfo
+    {
+        public string City { get; init; } = "";
+        public string Country { get; init; } = "";
     }
 
     [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/Tests/SearchLite.Tests/Postgres/WhereClauseTests.cs
+++ b/Tests/SearchLite.Tests/Postgres/WhereClauseTests.cs
@@ -20,6 +20,19 @@ public class WhereClauseTests
         String2
     }
 
+    public class Address
+    {
+        public required string City { get; set; }
+    }
+
+    public class Author
+    {
+        public required string Name { get; set; }
+        public int Rank { get; set; }
+        public required Address Address { get; set; }
+        public required List<string> Roles { get; set; }
+    }
+
     public class TestModel
     {
         public int Age { get; set; }
@@ -30,6 +43,8 @@ public class WhereClauseTests
         public DateTime CreatedAt { get; set; }
         public TestEnum EnumValue { get; set; }
         public TestStringEnum StringEnumValue { get; set; }
+        public required Author Author { get; set; }
+        public required List<string> Labels { get; set; }
     }
 
     [Fact]
@@ -47,9 +62,9 @@ public class WhereClauseTests
     {
         var clause = BuildClause(x => x.EnumValue == TestEnum.Value2);
 
-        clause.Sql.Should().Be("(document->>'EnumValue')::integer = @p0");
+        clause.Sql.Should().Be("document @> @p0::jsonb");
         clause.Parameters.Should().HaveCount(1);
-        clause.Parameters[0].Value.Should().Be((int)TestEnum.Value2);
+        clause.Parameters[0].Value.Should().Be($"{{\"EnumValue\":{(int)TestEnum.Value2}}}");
     }
 
     [Fact]
@@ -57,9 +72,9 @@ public class WhereClauseTests
     {
         var clause = BuildClause(x => x.StringEnumValue == TestStringEnum.String2);
 
-        clause.Sql.Should().Be("(document->>'StringEnumValue')::text = @p0");
+        clause.Sql.Should().Be("document @> @p0::jsonb");
         clause.Parameters.Should().HaveCount(1);
-        clause.Parameters[0].Value.Should().Be(nameof(TestStringEnum.String2));
+        clause.Parameters[0].Value.Should().Be($"{{\"StringEnumValue\":\"{nameof(TestStringEnum.String2)}\"}}");
     }
 
     [Fact]
@@ -67,18 +82,18 @@ public class WhereClauseTests
     {
         var clause = BuildClause(x => x.Name == "John");
 
-        clause.Sql.Should().Be("(document->>'Name')::text = @p0");
+        clause.Sql.Should().Be("document @> @p0::jsonb");
         clause.Parameters.Should().HaveCount(1);
-        clause.Parameters[0].Value.Should().Be("John");
+        clause.Parameters[0].Value.Should().Be("{\"Name\":\"John\"}");
     }
 
     [Fact]
     public void Should_Handle_Boolean_Comparison()
     {
         var clause = BuildClause(x => x.IsActive == true);
-        clause.Sql.Should().Be("(document->>'IsActive')::boolean = @p0");
+        clause.Sql.Should().Be("document @> @p0::jsonb");
         clause.Parameters.Should().HaveCount(1);
-        clause.Parameters[0].Value.Should().Be(true);
+        clause.Parameters[0].Value.Should().Be("{\"IsActive\":true}");
     }
 
     [Fact]
@@ -116,10 +131,10 @@ public class WhereClauseTests
     {
         var clause = BuildClause(x => x.Age > 18 && x.IsActive == true);
 
-        clause.Sql.Should().Be("((document->>'Age')::integer > @p0 AND (document->>'IsActive')::boolean = @p1)");
+        clause.Sql.Should().Be("((document->>'Age')::integer > @p0 AND document @> @p1::jsonb)");
         clause.Parameters.Should().HaveCount(2);
         clause.Parameters[0].Value.Should().Be(18);
-        clause.Parameters[1].Value.Should().Be(true);
+        clause.Parameters[1].Value.Should().Be("{\"IsActive\":true}");
     }
 
     [Fact]
@@ -127,10 +142,10 @@ public class WhereClauseTests
     {
         var clause = BuildClause(x => x.Name == "John" || x.Name == "Jane");
 
-        clause.Sql.Should().Be("((document->>'Name')::text = @p0 OR (document->>'Name')::text = @p1)");
+        clause.Sql.Should().Be("(document @> @p0::jsonb OR document @> @p1::jsonb)");
         clause.Parameters.Should().HaveCount(2);
-        clause.Parameters[0].Value.Should().Be("John");
-        clause.Parameters[1].Value.Should().Be("Jane");
+        clause.Parameters[0].Value.Should().Be("{\"Name\":\"John\"}");
+        clause.Parameters[1].Value.Should().Be("{\"Name\":\"Jane\"}");
     }
 
     [Fact]
@@ -140,13 +155,13 @@ public class WhereClauseTests
             (x.Age > 18 && x.IsActive == true) || (x.Score >= 95.5 && x.Name == "John"));
 
         clause.Sql.Should().Be(
-            "(((document->>'Age')::integer > @p0 AND (document->>'IsActive')::boolean = @p1) OR " +
-            "((document->>'Score')::numeric >= @p2 AND (document->>'Name')::text = @p3))");
+            "(((document->>'Age')::integer > @p0 AND document @> @p1::jsonb) OR " +
+            "((document->>'Score')::numeric >= @p2 AND document @> @p3::jsonb))");
         clause.Parameters.Should().HaveCount(4);
         clause.Parameters[0].Value.Should().Be(18);
-        clause.Parameters[1].Value.Should().Be(true);
+        clause.Parameters[1].Value.Should().Be("{\"IsActive\":true}");
         clause.Parameters[2].Value.Should().Be(95.5);
-        clause.Parameters[3].Value.Should().Be("John");
+        clause.Parameters[3].Value.Should().Be("{\"Name\":\"John\"}");
     }
 
     [Fact]
@@ -162,25 +177,41 @@ public class WhereClauseTests
 
         clauses.Should().HaveCount(2);
         clauses[0].Sql.Should().Be("(document->>'Age')::integer > @p0");
-        clauses[1].Sql.Should().Be("(document->>'IsActive')::boolean = @p0");
+        clauses[1].Sql.Should().Be("document @> @p0::jsonb");
         clauses[0].Parameters.Should().HaveCount(1);
         clauses[1].Parameters.Should().HaveCount(1);
+        clauses[1].Parameters[0].Value.Should().Be("{\"IsActive\":true}");
     }
 
     [Fact]
     public void Should_Handle_All_Comparison_Operators()
     {
-        (Expression<Func<TestModel, bool>> expression, string expected)[] cases =
+        // Equal/NotEqual on integer (containment-eligible) use JSONB @> with a JSON-number leaf.
+        (Expression<Func<TestModel, bool>> expression, string expectedSql, object expectedParam)[] containmentCases =
         [
-            (x => x.Age == 18, "(document->>'Age')::integer = @p0"),
-            (x => x.Age != 18, "(document->>'Age')::integer != @p0"),
+            (x => x.Age == 18, "document @> @p0::jsonb", "{\"Age\":18}"),
+            (x => x.Age != 18, "NOT (document @> @p0::jsonb)", "{\"Age\":18}")
+        ];
+
+        foreach (var testCase in containmentCases)
+        {
+            var clause = BuildClause(testCase.expression);
+
+            clause.Sql.Should().Be(testCase.expectedSql);
+            clause.Parameters.Should().HaveCount(1);
+            clause.Parameters[0].Value.Should().Be(testCase.expectedParam);
+        }
+
+        // Range comparisons keep the cast-and-compare form.
+        (Expression<Func<TestModel, bool>> expression, string expected)[] comparisonCases =
+        [
             (x => x.Age > 18, "(document->>'Age')::integer > @p0"),
             (x => x.Age >= 18, "(document->>'Age')::integer >= @p0"),
             (x => x.Age < 18, "(document->>'Age')::integer < @p0"),
             (x => x.Age <= 18, "(document->>'Age')::integer <= @p0")
         ];
 
-        foreach (var testCase in cases)
+        foreach (var testCase in comparisonCases)
         {
             var clause = BuildClause(testCase.expression);
 
@@ -211,6 +242,95 @@ public class WhereClauseTests
         
         paramNames.Should().Contain("@p0");
         paramNames.Should().Contain("@p1");
+    }
+
+    [Fact]
+    public void Should_Handle_Nested_String_Equality_With_Containment()
+    {
+        var clause = BuildClause(x => x.Author.Name == "Alice");
+
+        clause.Sql.Should().Be("document @> @p0::jsonb");
+        clause.Parameters.Should().HaveCount(1);
+        clause.Parameters[0].Value.Should().Be("{\"Author\":{\"Name\":\"Alice\"}}");
+    }
+
+    [Fact]
+    public void Should_Handle_Deeply_Nested_String_Equality_With_Containment()
+    {
+        var clause = BuildClause(x => x.Author.Address.City == "Oslo");
+
+        clause.Sql.Should().Be("document @> @p0::jsonb");
+        clause.Parameters.Should().HaveCount(1);
+        clause.Parameters[0].Value.Should().Be("{\"Author\":{\"Address\":{\"City\":\"Oslo\"}}}");
+    }
+
+    [Fact]
+    public void Should_Handle_Nested_Integer_Equality_With_Containment()
+    {
+        var clause = BuildClause(x => x.Author.Rank == 5);
+
+        clause.Sql.Should().Be("document @> @p0::jsonb");
+        clause.Parameters.Should().HaveCount(1);
+        clause.Parameters[0].Value.Should().Be("{\"Author\":{\"Rank\":5}}");
+    }
+
+    [Fact]
+    public void Should_Handle_Nested_Comparison_With_Path_Accessor()
+    {
+        var clause = BuildClause(x => x.Author.Rank > 3);
+
+        clause.Sql.Should().Be("(document #>> '{Author,Rank}')::integer > @p0");
+        clause.Parameters.Should().HaveCount(1);
+        clause.Parameters[0].Value.Should().Be(3);
+    }
+
+    [Fact]
+    public void Should_Handle_Nested_Null_Check_With_Path_Accessor()
+    {
+        var clause = BuildClause(x => x.Author.Name == null);
+
+        clause.Sql.Should().Be("(document #>> '{Author,Name}') IS NULL");
+        clause.Parameters.Should().HaveCount(0);
+    }
+
+    [Fact]
+    public void Should_Handle_Nested_String_Operation_With_Path_Accessor()
+    {
+        var clause = BuildClause(x => x.Author.Name.Contains("li"));
+
+        clause.Sql.Should().Be("(document #>> '{Author,Name}')::text LIKE @p0");
+        clause.Parameters.Should().HaveCount(1);
+        clause.Parameters[0].Value.Should().Be("%li%");
+    }
+
+    [Fact]
+    public void Should_Handle_CollectionContains_TopLevel()
+    {
+        var clause = BuildClause(x => x.Labels.Contains("urgent"));
+
+        clause.Sql.Should().Be("document @> @p0::jsonb");
+        clause.Parameters.Should().HaveCount(1);
+        clause.Parameters[0].Value.Should().Be("{\"Labels\":[\"urgent\"]}");
+    }
+
+    [Fact]
+    public void Should_Handle_CollectionNotContains_TopLevel()
+    {
+        var clause = BuildClause(x => !x.Labels.Contains("urgent"));
+
+        clause.Sql.Should().Be("NOT (document @> @p0::jsonb)");
+        clause.Parameters.Should().HaveCount(1);
+        clause.Parameters[0].Value.Should().Be("{\"Labels\":[\"urgent\"]}");
+    }
+
+    [Fact]
+    public void Should_Handle_CollectionContains_Nested()
+    {
+        var clause = BuildClause(x => x.Author.Roles.Contains("admin"));
+
+        clause.Sql.Should().Be("document @> @p0::jsonb");
+        clause.Parameters.Should().HaveCount(1);
+        clause.Parameters[0].Value.Should().Be("{\"Author\":{\"Roles\":[\"admin\"]}}");
     }
 
     private static Clause BuildClause(Expression<Func<TestModel, bool>> predicate) => BuildClauses(predicate).Single();

--- a/Tests/SearchLite.Tests/SearchLite.Tests.csproj
+++ b/Tests/SearchLite.Tests/SearchLite.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/SearchLite.Tests/Sqlite/WhereClauseTests.cs
+++ b/Tests/SearchLite.Tests/Sqlite/WhereClauseTests.cs
@@ -20,6 +20,19 @@ public class WhereClauseTests
         String2
     }
 
+    public class TestAddress
+    {
+        public required string City { get; set; }
+    }
+
+    public class TestAuthor
+    {
+        public required string Name { get; set; }
+        public int Age { get; set; }
+        public required TestAddress Address { get; set; }
+        public required List<string> Roles { get; set; }
+    }
+
     public class TestModel
     {
         public int Age { get; set; }
@@ -30,6 +43,8 @@ public class WhereClauseTests
         public DateTime CreatedAt { get; set; }
         public TestEnum EnumValue { get; set; }
         public TestStringEnum StringEnumValue { get; set; }
+        public required List<string> Labels { get; set; }
+        public required TestAuthor Author { get; set; }
     }
 
     [Fact]
@@ -193,6 +208,85 @@ public class WhereClauseTests
             clause.Parameters.Should().HaveCount(1);
             clause.Parameters[0].Value.Should().Be(18);
         }
+    }
+
+    [Fact]
+    public void Should_Handle_Nested_String_Equality()
+    {
+        var clause = BuildClause(x => x.Author.Name == "John");
+
+        clause.Sql.Should().Be("CAST(json_extract(document, '$.Author.Name') AS TEXT) = @p0");
+        clause.Parameters.Should().HaveCount(1);
+        clause.Parameters[0].Value.Should().Be("John");
+    }
+
+    [Fact]
+    public void Should_Handle_Nested_Integer_Comparison()
+    {
+        var clause = BuildClause(x => x.Author.Age > 18);
+
+        clause.Sql.Should().Be("CAST(json_extract(document, '$.Author.Age') AS INTEGER) > @p0");
+        clause.Parameters.Should().HaveCount(1);
+        clause.Parameters[0].Value.Should().Be(18);
+    }
+
+    [Fact]
+    public void Should_Handle_Deeply_Nested_String_Equality()
+    {
+        var clause = BuildClause(x => x.Author.Address.City == "Oslo");
+
+        clause.Sql.Should().Be("CAST(json_extract(document, '$.Author.Address.City') AS TEXT) = @p0");
+        clause.Parameters.Should().HaveCount(1);
+        clause.Parameters[0].Value.Should().Be("Oslo");
+    }
+
+    [Fact]
+    public void Should_Handle_Nested_Null_Check()
+    {
+        var clause = BuildClause(x => x.Author.Name == null);
+
+        clause.Sql.Should().Be("json_extract(document, '$.Author.Name') IS NULL");
+        clause.Parameters.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Should_Handle_Nested_String_Operator()
+    {
+        var clause = BuildClause(x => x.Author.Name.Contains("oh"));
+
+        clause.Sql.Should().Be("CAST(json_extract(document, '$.Author.Name') AS TEXT) GLOB @p0");
+        clause.Parameters.Should().HaveCount(1);
+        clause.Parameters[0].Value.Should().Be("*oh*");
+    }
+
+    [Fact]
+    public void Should_Handle_CollectionContains()
+    {
+        var clause = BuildClause(x => x.Labels.Contains("urgent"));
+
+        clause.Sql.Should().Be("EXISTS (SELECT 1 FROM json_each(document, '$.Labels') WHERE value = @p0)");
+        clause.Parameters.Should().HaveCount(1);
+        clause.Parameters[0].Value.Should().Be("urgent");
+    }
+
+    [Fact]
+    public void Should_Handle_CollectionNotContains()
+    {
+        var clause = BuildClause(x => !x.Labels.Contains("urgent"));
+
+        clause.Sql.Should().Be("NOT EXISTS (SELECT 1 FROM json_each(document, '$.Labels') WHERE value = @p0)");
+        clause.Parameters.Should().HaveCount(1);
+        clause.Parameters[0].Value.Should().Be("urgent");
+    }
+
+    [Fact]
+    public void Should_Handle_Nested_CollectionContains()
+    {
+        var clause = BuildClause(x => x.Author.Roles.Contains("admin"));
+
+        clause.Sql.Should().Be("EXISTS (SELECT 1 FROM json_each(document, '$.Author.Roles') WHERE value = @p0)");
+        clause.Parameters.Should().HaveCount(1);
+        clause.Parameters[0].Value.Should().Be("admin");
     }
 
     private static Clause BuildClause(Expression<Func<TestModel, bool>> predicate) => BuildClauses(predicate).Single();

--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,57 @@ var request = new SearchRequest<Product>
 .Where(p => p.Price >= 1000 && p.Price <= 2000);
 ```
 
+### Nested fields
+
+Filters and ordering can reach into nested objects within a document, at any depth:
+
+```csharp
+// Documents can hold nested objects and collections
+public class Product : ISearchableDocument
+{
+    public string Id { get; set; }
+    public string Name { get; set; }
+    public Manufacturer Maker { get; set; }   // nested object
+    public List<string> Tags { get; set; }    // collection field
+    public string GetSearchText() => $"{Id} {Name}";
+}
+
+public class Manufacturer
+{
+    public string Name { get; set; }
+    public Address HeadOffice { get; set; }
+}
+
+// Filter and order by nested fields
+var request = new SearchRequest<Product>()
+    .Where(p => p.Maker.Name == "Acme" && p.Maker.HeadOffice.City == "Oslo")
+    .OrderByAscending(p => p.Maker.Name);
+```
+
+### Collection (array) membership
+
+Use `Contains` on a document's own collection field to match documents whose array
+holds a given value:
+
+```csharp
+// Match products tagged "sale"
+.Where(p => p.Tags.Contains("sale"))
+
+// Negation works too
+.Where(p => !p.Tags.Contains("discontinued"))
+```
+
+> This is distinct from `In`-style filters, where a fixed set is tested against a single
+> field — e.g. `var ids = new[] { "1", "2" }; request.Where(p => ids.Contains(p.Id));`
+
+### Efficient execution on PostgreSQL
+
+On PostgreSQL, equality and collection-membership filters compile to JSONB containment
+(`document @> '{...}'`), which is served by the `GIN(jsonb_path_ops)` index SearchLite
+creates on every index — so these filters stay fast as collections grow. Range and string
+comparisons use JSON path extraction. SQLite provides the same query capabilities using
+`json_extract` and `json_each`.
+
 ## Advanced Usage
 
 ### Batch Indexing

--- a/readme.nuget.md
+++ b/readme.nuget.md
@@ -60,6 +60,18 @@ foreach (var match in results.Matches)
 }
 ```
 
+## Filtering
+
+LINQ-style `Where` filters support nested document fields and collection membership, across
+both backends:
+
+```csharp
+.Where(p => p.Maker.HeadOffice.City == "Oslo")   // nested fields, any depth
+.Where(p => p.Tags.Contains("sale"))             // array/list membership
+```
+
+On PostgreSQL these compile to JSONB containment (`@>`) and use the GIN index for fast lookups.
+
 ## Learn More
 
 For detailed documentation, advanced usage, and contributing guidelines, visit the [SearchLite GitHub Repository](https://github.com/mhelleborg/searchlite).


### PR DESCRIPTION
Filters and ordering can now reach into nested document objects at any depth
(e.g. d.Author.Address.City == "Oslo"), and a document's own array/list fields
can be filtered with Contains (e.g. d.Tags.Contains("urgent")).

Core:
- FilterNode.Condition.PropertyName now carries a dot-separated path for nested
  fields; single-segment paths are unchanged.
- New operators CollectionContains / CollectionNotContains model "array field
  holds value", distinct from In/NotIn (value-set membership).
- FieldPath helper builds/splits parameter-rooted member paths.
- FilterMapper extracts full paths and disambiguates constantCollection.Contains
  (In) from documentArray.Contains(constant) (CollectionContains); OrderByMapper
  supports nested paths.

Postgres (efficient execution):
- Equality and collection-containment compile to JSONB @> so the existing
  GIN(jsonb_path_ops) index is used (verified via EXPLAIN: Bitmap Index Scan).
- Range/string/null filters use path-aware ->> / #>> accessors; non-eligible
  types (double/decimal/float/DateTime) keep cast-and-compare for correctness.

SQLite (capability parity):
- Nested fields via json_extract dotted paths; collection membership via
  EXISTS (SELECT 1 FROM json_each(...) WHERE value = @p).

Tests: shared LINQ-equivalence contract (nested fields, nested OrderBy, array
Contains) inherited by both backends; FilterMapper path/operator unit tests;
provider SQL-shape tests. README documents the new query surface.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017qH9TPB7garYGstkWsxnEL